### PR TITLE
Remove useless method in GalleryComponent.

### DIFF
--- a/app/src/main/java/ru/ltst/u2020mvp/ui/gallery/GalleryComponent.java
+++ b/app/src/main/java/ru/ltst/u2020mvp/ui/gallery/GalleryComponent.java
@@ -11,5 +11,4 @@ import ru.ltst.u2020mvp.ui.gallery.view.GalleryView;
 )
 public interface GalleryComponent extends GalleryView.Injector {
     void inject(GalleryActivity activity);
-    GalleryActivity.Presenter presenter();
 }


### PR DESCRIPTION
Remove an useless accessor method exposed by interface GalleryComponent.
